### PR TITLE
Update apt's package cache before attempting to install any packages

### DIFF
--- a/debian-9.sh
+++ b/debian-9.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+echo "Updating package cache"
+apt-get update
+echo
 echo "Preparing OpenVPN 2 build environment"
 echo
 apt-get -y install liblzo2-dev libssl1.0-dev libpam-dev libpkcs11-helper1-dev libtool autoconf make cmake git fping net-tools liblz4-dev

--- a/ubuntu-1604.sh
+++ b/ubuntu-1604.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+echo "Updating package cache"
+apt-get update
+echo
 echo "Preparing OpenVPN 2 build environment"
 echo
 apt-get -y install liblzo2-dev libssl-dev libpam-dev libpkcs11-helper1-dev libtool autoconf make cmake git net-tools liblz4-dev


### PR DESCRIPTION
Without this installation of some packages during provisioning may fail

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>