### PR TITLE
Add MSI build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ These VMs are special-purpose:
 
 * openvpn-build: cross-compile OpenVPN using [openvpn-build](https://github.com/OpenVPN/openvpn-build) (Ubuntu 16.04)
 * openvpn-build-bionic: cross-compile OpenVPN using [openvpn-build](https://github.com/OpenVPN/openvpn-build) (Ubuntu 18.04)
+* sbuild: build OpenVPN 2.x Debian/Ubuntu packages using [sbuild_wrapper](https://github.com/OpenVPN/sbuild_wrapper) (Ubuntu 18.04)
+* oas: [OpenVPN Access Server](https://openvpn.net/faq/what-is-openvpn-access-server/) for testing / experimentation (Ubuntu 18.04)
 * msibuilder: package OpenVPN as MSI using the [WiX toolset](http://wixtoolset.org) (Windows Server 2016)
 
 # Building MSI packages

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -151,4 +151,17 @@ Vagrant.configure("2") do |config|
       vb.memory = 2048
     end
   end
+
+  config.vm.define "msibuilder" do |box|
+    box.vm.box = "mwrock/Windows2016"
+    box.vm.box_version = "0.3.0"
+    box.vm.hostname = "msibuilder"
+    box.vm.network "private_network", ip: "192.168.48.113"
+    box.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+    box.vm.provision "shell", path: "msibuilder.ps1"
+    box.vm.provider "virtualbox" do |vb|
+      vb.gui = false
+      vb.memory = 3072
+    end
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -145,7 +145,7 @@ Vagrant.configure("2") do |config|
     box.vm.box_version = "20191030.0.0"
     box.vm.hostname = "oas.local"
     box.vm.network "private_network", ip: "192.168.48.112"
-    #box.vm.provision "shell", path: "oas.sh"
+    box.vm.provision "shell", path: "oas.sh"
     box.vm.provider "virtualbox" do |vb|
       vb.gui = false
       vb.memory = 2048

--- a/msibuilder.ps1
+++ b/msibuilder.ps1
@@ -1,0 +1,31 @@
+# Preferred language and keyboard layout
+$lang = "fi-FI"
+
+# Reset eveluation timer if necessary. This can be repeated six times and each
+# gives 180 extra days of evaluation use.
+if ((Get-Ciminstance -Class SoftwareLicensingProduct).LicenseStatus -ne 1) {
+    Write-Host "Resetting license evaluation timer"
+    & slmgr.vbs //B -rearm
+    $need_restart = $true
+}
+
+Write-Host "Setting keyboard layouts"
+$languages = New-WinUserLanguageList -Language $lang
+$languages.Add($lang)
+Set-WinUserLanguageList $languages -Force
+
+if (-Not (Test-Path C:\ProgramData\chocolatey\bin\choco.exe)) {
+    Write-Host "Installing Chocolatey"
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+}
+
+Write-Host "Installing software"
+& choco.exe install -y git --params "/GitAndUnixToolsOnPath"
+& choco.exe install -y wixtoolset
+
+if ($need_restart) {
+    Write-Host "Rebooting to finish the license evaluation timer reset"
+    # We need to schedule the restart or Vagrant will loose the WinRM
+    # connection and destroy the instance as a result.
+    shutdown /r /t 10
+}


### PR DESCRIPTION
This includes adding a Samba server to openvpn-build-bionic to share build
artefacts with msibuilder, a new Windows Server 2016 VM. The new provisioning
scripts should work outside of Vagrant with minor modifications.

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>