### PR TITLE
Documentation and provisioning fixes related to MSI packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,12 @@ shared by openvpn-build-bionic:
 
     PS> net use O: /USER:vagrant /PERSISTENT:YES \\192.168.48.110\openvpn-build vagrant
 
-For now you need to switch to the codebase that has MSI support:
+Now SSH in to openvpn-build-bionic and build both 32-bit and 64-bit binaries.
+Until OpenVPN 2.5 is officially out you need to point the build system to an
+OpenVPN tarball that has MSI support:
 
     $ vagrant ssh openvpn-build-bionic
-    $ chown -R vagrant:vagrant openvpn-build
-    $ cd openvpn-build
-    $ git remote add rozmansi https://github.com/rozmansi/openvpn-build.git
-    $ git fetch rozmansi
-    $ git checkout -b msi rozmansi/feature/msi
-
-Make sure that OPENVPN_URL is pointing to a recent OpenVPN 2.5 tarball which
-has the MSI support patches. Then build both 32-bit and 64-bit binaries:
-
-    $ cd generic
+    $ cd openvpn-build/generic
     $ OPENVPN_URL=http://build.openvpn.net/downloads/temp/msi/openvpn-2.5_git.tar.gz IMAGEROOT=`pwd`/image-win32 CHOST=i686-w64-mingw32 CBUILD=x86_64-pc-linux-gnu ./build
     $ OPENVPN_URL=http://build.openvpn.net/downloads/temp/msi/openvpn-2.5_git.tar.gz IMAGEROOT=`pwd`/image-win64 CHOST=x86_64-w64-mingw32 CBUILD=x86_64-pc-linux-gnu ./build
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -122,6 +122,7 @@ Vagrant.configure("2") do |config|
       s.path = "setup-generic-buildsystem.sh"
       s.args = ["-f"]
     end
+    box.vm.provision "shell", path: "setup-samba-share.sh"
     box.vm.provider "virtualbox" do |vb|
       vb.gui = false
       vb.memory = 1024

--- a/setup-samba-share.sh
+++ b/setup-samba-share.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Setup a Samba share so that msibuilder VM can access build artefacts
+
+share_dir="/home/vagrant/openvpn-build"
+share_name="openvpn-build"
+samba_user="vagrant"
+samba_password="vagrant"
+smb_conf_tmpl_src="/vagrant/smb.conf.tmpl"
+smb_conf_tmpl_dst="/etc/samba/smb.conf.tmpl"
+
+echo "Installing Samba server and client"
+apt-get -y install samba smbclient
+
+echo "Enabling Samba share"
+test -d $share_dir || mkdir -p $share_dir
+chmod 755 $share_dir
+mkdir -p /etc/samba
+touch /etc/samba/smb.conf
+test -f /etc/samba/smb.conf.dist || cp -v /etc/samba/smb.conf /etc/samba/smb.conf.dist
+cp -v $smb_conf_tmpl_src $smb_conf_tmpl_dst
+
+# Sed will get confused about the slashes in the share directory path unless
+# we use something else as a separator
+sed -i "s+==SHARE_DIR==+$share_dir+g" $smb_conf_tmpl_dst
+sed -i "s/==SHARE_NAME==/$share_name/g" $smb_conf_tmpl_dst
+sed -i "s/==SAMBA_USER==/$samba_user/g" $smb_conf_tmpl_dst
+cmp $smb_conf_tmpl_dst /etc/samba/smb.conf
+if [ $? -ne 0 ]; then
+    mv $smb_conf_tmpl_dst /etc/samba/smb.conf
+else
+    rm -f $smb_conf_tmpl_dst
+fi
+
+pdbedit -L|grep "^${samba_user}:" > /dev/null
+if [ $? -ne 0 ]; then
+    echo "Adding samba user \"${samba_user}\" with password \"${samba_password}\""
+    yes $samba_password|head -n 2|smbpasswd -a -s $samba_user
+fi
+
+systemctl restart smbd

--- a/smb.conf.tmpl
+++ b/smb.conf.tmpl
@@ -1,0 +1,276 @@
+#
+# Sample configuration file for the Samba suite for Debian GNU/Linux.
+#
+#
+# This is the main Samba configuration file. You should read the
+# smb.conf(5) manual page in order to understand the options listed
+# here. Samba has a huge number of configurable options most of which 
+# are not shown in this example
+#
+# Some options that are often worth tuning have been included as
+# commented-out examples in this file.
+#  - When such options are commented with ";", the proposed setting
+#    differs from the default Samba behaviour
+#  - When commented with "#", the proposed setting is the default
+#    behaviour of Samba but the option is considered important
+#    enough to be mentioned here
+#
+# NOTE: Whenever you modify this file you should run the command
+# "testparm" to check that you have not made any basic syntactic 
+# errors. 
+
+#======================= Global Settings =======================
+
+[global]
+
+## Browsing/Identification ###
+
+# Change this to the workgroup/NT-domain name your Samba server will part of
+   workgroup = vagrant
+
+# server string is the equivalent of the NT Description field
+	server string = %h server (Samba, Ubuntu)
+
+# Windows Internet Name Serving Support Section:
+# WINS Support - Tells the NMBD component of Samba to enable its WINS Server
+#   wins support = no
+
+# WINS Server - Tells the NMBD components of Samba to be a WINS Client
+# Note: Samba can be either a WINS Server, or a WINS Client, but NOT both
+;   wins server = w.x.y.z
+
+# This will prevent nmbd to search for NetBIOS names through DNS.
+   dns proxy = no
+
+#### Networking ####
+
+# The specific set of interfaces / networks to bind to
+# This can be either the interface name or an IP address/netmask;
+# interface names are normally preferred
+;   interfaces = 127.0.0.0/8 eth0
+
+# Only bind to the named interfaces and/or networks; you must use the
+# 'interfaces' option above to use this.
+# It is recommended that you enable this feature if your Samba machine is
+# not protected by a firewall or is a firewall itself.  However, this
+# option cannot handle dynamic or non-broadcast interfaces correctly.
+;   bind interfaces only = yes
+
+
+
+#### Debugging/Accounting ####
+
+# This tells Samba to use a separate log file for each machine
+# that connects
+   log file = /var/log/samba/log.%m
+
+# Cap the size of the individual log files (in KiB).
+   max log size = 1000
+
+# If you want Samba to only log through syslog then set the following
+# parameter to 'yes'.
+#   syslog only = no
+
+# We want Samba to log a minimum amount of information to syslog. Everything
+# should go to /var/log/samba/log.{smbd,nmbd} instead. If you want to log
+# through syslog you should set the following parameter to something higher.
+   syslog = 0
+
+# Do something sensible when Samba crashes: mail the admin a backtrace
+   panic action = /usr/share/samba/panic-action %d
+
+
+####### Authentication #######
+
+# Server role. Defines in which mode Samba will operate. Possible
+# values are "standalone server", "member server", "classic primary
+# domain controller", "classic backup domain controller", "active
+# directory domain controller". 
+#
+# Most people will want "standalone sever" or "member server".
+# Running as "active directory domain controller" will require first
+# running "samba-tool domain provision" to wipe databases and create a
+# new domain.
+   server role = standalone server
+
+# If you are using encrypted passwords, Samba will need to know what
+# password database type you are using.  
+   passdb backend = tdbsam
+
+   obey pam restrictions = yes
+
+# This boolean parameter controls whether Samba attempts to sync the Unix
+# password with the SMB password when the encrypted SMB password in the
+# passdb is changed.
+   unix password sync = yes
+
+# For Unix password sync to work on a Debian GNU/Linux system, the following
+# parameters must be set (thanks to Ian Kahan <<kahan@informatik.tu-muenchen.de> for
+# sending the correct chat script for the passwd program in Debian Sarge).
+   passwd program = /usr/bin/passwd %u
+   passwd chat = *Enter\snew\s*\spassword:* %n\n *Retype\snew\s*\spassword:* %n\n *password\supdated\ssuccessfully* .
+
+# This boolean controls whether PAM will be used for password changes
+# when requested by an SMB client instead of the program listed in
+# 'passwd program'. The default is 'no'.
+   pam password change = yes
+
+# This option controls how unsuccessful authentication attempts are mapped
+# to anonymous connections
+   map to guest = bad user
+
+########## Domains ###########
+
+#
+# The following settings only takes effect if 'server role = primary
+# classic domain controller', 'server role = backup domain controller'
+# or 'domain logons' is set 
+#
+
+# It specifies the location of the user's
+# profile directory from the client point of view) The following
+# required a [profiles] share to be setup on the samba server (see
+# below)
+;   logon path = \\%N\profiles\%U
+# Another common choice is storing the profile in the user's home directory
+# (this is Samba's default)
+#   logon path = \\%N\%U\profile
+
+# The following setting only takes effect if 'domain logons' is set
+# It specifies the location of a user's home directory (from the client
+# point of view)
+;   logon drive = H:
+#   logon home = \\%N\%U
+
+# The following setting only takes effect if 'domain logons' is set
+# It specifies the script to run during logon. The script must be stored
+# in the [netlogon] share
+# NOTE: Must be store in 'DOS' file format convention
+;   logon script = logon.cmd
+
+# This allows Unix users to be created on the domain controller via the SAMR
+# RPC pipe.  The example command creates a user account with a disabled Unix
+# password; please adapt to your needs
+; add user script = /usr/sbin/adduser --quiet --disabled-password --gecos "" %u
+
+# This allows machine accounts to be created on the domain controller via the 
+# SAMR RPC pipe.  
+# The following assumes a "machines" group exists on the system
+; add machine script  = /usr/sbin/useradd -g machines -c "%u machine account" -d /var/lib/samba -s /bin/false %u
+
+# This allows Unix groups to be created on the domain controller via the SAMR
+# RPC pipe.  
+; add group script = /usr/sbin/addgroup --force-badname %g
+
+############ Misc ############
+
+# Using the following line enables you to customise your configuration
+# on a per machine basis. The %m gets replaced with the netbios name
+# of the machine that is connecting
+;   include = /home/samba/etc/smb.conf.%m
+
+# Some defaults for winbind (make sure you're not using the ranges
+# for something else.)
+;   idmap uid = 10000-20000
+;   idmap gid = 10000-20000
+;   template shell = /bin/bash
+
+# Setup usershare options to enable non-root users to share folders
+# with the net usershare command.
+
+# Maximum number of usershare. 0 (default) means that usershare is disabled.
+;   usershare max shares = 100
+
+# Allow users who've been granted usershare privileges to create
+# public shares, not just authenticated ones
+   usershare allow guests = yes
+
+#======================= Share Definitions =======================
+
+# Un-comment the following (and tweak the other settings below to suit)
+# to enable the default home directory shares. This will share each
+# user's home directory as \\server\username
+;[homes]
+;   comment = Home Directories
+;   browseable = no
+
+# By default, the home directories are exported read-only. Change the
+# next parameter to 'no' if you want to be able to write to them.
+;   read only = yes
+
+# File creation mask is set to 0700 for security reasons. If you want to
+# create files with group=rw permissions, set next parameter to 0775.
+;   create mask = 0700
+
+# Directory creation mask is set to 0700 for security reasons. If you want to
+# create dirs. with group=rw permissions, set next parameter to 0775.
+;   directory mask = 0700
+
+# By default, \\server\username shares can be connected to by anyone
+# with access to the samba server.
+# Un-comment the following parameter to make sure that only "username"
+# can connect to \\server\username
+# This might need tweaking when using external authentication schemes
+;   valid users = %S
+
+# Un-comment the following and create the netlogon directory for Domain Logons
+# (you need to configure Samba to act as a domain controller too.)
+;[netlogon]
+;   comment = Network Logon Service
+;   path = /home/samba/netlogon
+;   guest ok = yes
+;   read only = yes
+
+# Un-comment the following and create the profiles directory to store
+# users profiles (see the "logon path" option above)
+# (you need to configure Samba to act as a domain controller too.)
+# The path below should be writable by all users so that their
+# profile directory may be created the first time they log on
+;[profiles]
+;   comment = Users profiles
+;   path = /home/samba/profiles
+;   guest ok = no
+;   browseable = no
+;   create mask = 0600
+;   directory mask = 0700
+ realm = vagrant.local
+ netbios name = SMB
+ security = user
+ vfs objects = acl_xattr
+ dedicated keytab file = /etc/krb5.keytab
+ map acl inherit = Yes
+ store dos attributes = Yes
+ map untrusted to domain = Yes
+ log level = 1
+
+[printers]
+   comment = All Printers
+   browseable = no
+   path = /var/spool/samba
+   printable = yes
+   guest ok = no
+   read only = yes
+   create mask = 0700
+
+# Windows clients look for this share name as a source of downloadable
+# printer drivers
+[print$]
+   comment = Printer Drivers
+   path = /var/lib/samba/printers
+   browseable = yes
+   read only = yes
+   guest ok = no
+# Uncomment to allow remote administration of Windows print drivers.
+# You may need to replace 'lpadmin' with the name of the group your
+# admin users are members of.
+# Please note that you also need to set appropriate Unix permissions
+# to the drivers directory for these users to have write rights in it
+;   write list = root, @lpadmin
+
+
+[==SHARE_NAME==]
+path = ==SHARE_DIR==
+browsable = Yes
+writeable = Yes
+force user = ==SAMBA_USER==
+force group = ==SAMBA_USER==


### PR DESCRIPTION
The old documentation was wrong. Also, the provisioning code setup the Samba shared on openvpn-build-bionic that msibuilder would use had fell victim to the "feature branch left unmerged too long" syndrome, so it was missing. Fix both of these issues.